### PR TITLE
Fixing Partial compilation

### DIFF
--- a/ssg-core/lib/precomp-pattern.js
+++ b/ssg-core/lib/precomp-pattern.js
@@ -28,7 +28,7 @@ module.exports = function(patternConfig) {
         // handlebars
         .pipe(handlebars(hbOptions))
         // wrap inline javascript
-        .pipe(wrap('Handlebars.registerPartial(<%= processPartialName(file.relative) %>,' +
+        .pipe(wrap('Handlebars.registerPartial(<%= imports.processPartialName(file.relative) %>,' +
             'Handlebars.template(<%= contents %>));', {}, {
                 imports: {
                     processPartialName: function(fileName) {


### PR DESCRIPTION
Partial compilation failed with the following error or similar:
[19:04:18] Plumber found unhandled error:
 ReferenceError in plugin 'gulp-wrap'
Message:
    imports is not defined
